### PR TITLE
Discard NotUsed error status for status transition

### DIFF
--- a/TinySato/Communication/JobStatus.cs
+++ b/TinySato/Communication/JobStatus.cs
@@ -87,6 +87,7 @@
                 // recoverable errors
                 case Error.CoverOpen:
                 case Error.Paper:
+                case Error.NotUsed:
                     break;
 
                 case Error.Head:
@@ -139,7 +140,7 @@
 
     public enum Buffer { NearFull, OK, Unknown }
 
-    public enum Error { None, Buffer, Paper, Battery, Sensor, Head, CoverOpen, Other }
+    public enum Error { None, Buffer, NotUsed, Paper, Battery, Sensor, Head, CoverOpen, Other }
 
     public struct Health
     {
@@ -177,6 +178,7 @@
             new Health('V', State.OnlineAnalyzing, Battery.NearEnd, Buffer.NearFull),
 
             new Health('a', Error.Buffer),
+            new Health('b', Error.NotUsed),
             new Health('c', Error.Paper),
             new Health('d', Error.Battery),
             new Health('f', Error.Sensor),


### PR DESCRIPTION
When the printer cover opens, it occurs 'b' status. After that, it goes to CoverOpen status.

The 'b' status is `Not Used`.
Reference: I Programming Reference For MB200i MB400i MB410i at https://www.satoamerica.com/resources/documentation/manuals
![image](https://user-images.githubusercontent.com/131623/83635314-fcc03880-a5de-11ea-8814-0af8998f48f6.png)
